### PR TITLE
Disables ssh agent mode

### DIFF
--- a/consul.tf
+++ b/consul.tf
@@ -9,6 +9,7 @@ resource "aws_instance" "server" {
     connection {
         user = "${lookup(var.user, var.platform)}"
         private_key = "${file("${var.key_path}")}"
+        agent = false
     }
 
     #Instance tags


### PR DESCRIPTION
Terraform used to fail in the middle of execution 

"Error connecting to SSH_AUTH_SOCK: dial unix /run/user/1000/keyring/ssh: connect: no such file or directory"

This change fixes the above issue.